### PR TITLE
Switch icons to SVG and update theme color

### DIFF
--- a/public/icons/README.md
+++ b/public/icons/README.md
@@ -2,32 +2,39 @@
 
 This directory contains the icon files for the Progressive Web App:
 
-- ✅ `icon-192x192.png` - 192x192px PNG icon for mobile home screen
-- ✅ `icon-512x512.png` - 512x512px PNG icon for splash screen and app store
+- ✅ `icon-192x192.svg` - 192x192px SVG icon for mobile home screen
+- ✅ `icon-512x512.svg` - 512x512px SVG icon for splash screen and app store
+- ✅ `favicon.svg` - 32x32px SVG favicon for browser tabs
 - ✅ `screenshot-mobile.png` - Mobile screenshot (390x844px) for app listings
 
 ## Icon Design
 
 The icons feature a modern stock chart design with the following characteristics:
 
-- **Theme Color**: Bootstrap primary blue (#0d6efd)
-- **Design**: Upward trending stock chart with data points
+- **Theme Color**: Navy blue (#1E4A73)
+- **Design**: Upward trending stock chart bars with arrow
 - **Style**: Professional financial app aesthetic
-- **Format**: PNG with RGBA transparency
-- **Optimization**: Optimized for web with minimal file sizes
+- **Format**: SVG (scalable vector graphics)
+- **Optimization**: Infinite scalability with minimal file sizes
 
 ## Technical Specifications
 
-### icon-192x192.png
-- Size: 192x192 pixels
-- Mode: RGBA (with transparency)
-- File size: ~1 KB
+### favicon.svg
+- Size: 32x32 viewBox (scalable)
+- Format: SVG
+- File size: ~400 bytes
+- Purpose: Browser tab favicon
+
+### icon-192x192.svg
+- Size: 192x192 viewBox (scalable)
+- Format: SVG with rounded corners (rx="42")
+- File size: ~700 bytes
 - Purpose: Mobile home screen icon
 
-### icon-512x512.png
-- Size: 512x512 pixels
-- Mode: RGBA (with transparency)
-- File size: ~3 KB
+### icon-512x512.svg
+- Size: 512x512 viewBox (scalable)
+- Format: SVG with rounded corners (rx="112")
+- File size: ~700 bytes
 - Purpose: Splash screen and high-resolution displays
 
 ### screenshot-mobile.png
@@ -39,14 +46,16 @@ The icons feature a modern stock chart design with the following characteristics
 ## Customization
 
 To customize these icons:
-1. Edit the generation script at `/tmp/generate_icons.py`
-2. Modify colors, chart style, or design elements
-3. Re-run the script to regenerate icons
+1. Edit the SVG files directly in any text editor
+2. Modify colors (background: #1E4A73, foreground: white)
+3. Adjust chart bar positions or arrow design
 4. Ensure icons maintain appropriate contrast and visibility at small sizes
 
 ## Tools Used
 
-Icons were generated using Python with PIL/Pillow:
-- Vector-based drawing for crisp rendering
+Icons are hand-crafted SVG files:
+- SVG format for infinite scalability
+- Navy blue background (#1E4A73) with white elements
+- Simple geometric shapes for optimal rendering
 - Optimized PNG compression
 - Professional color scheme matching app theme

--- a/public/icons/favicon.svg
+++ b/public/icons/favicon.svg
@@ -1,0 +1,17 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background with rounded corners -->
+  <rect width="32" height="32" rx="7" fill="#1E4A73"/>
+  
+  <!-- Chart bars (simplified for small size) -->
+  <rect x="11" y="19" width="3" height="5" rx="0.5" fill="white"/>
+  <rect x="15.5" y="14" width="3" height="10" rx="0.5" fill="white"/>
+  <rect x="20" y="16" width="3" height="8" rx="0.5" fill="white"/>
+  
+  <!-- Upward arrow -->
+  <path d="M16.5 8 L16.5 19 M16.5 8 L14 10.5 M16.5 8 L19 10.5" 
+        stroke="white" 
+        stroke-width="1.5" 
+        stroke-linecap="round" 
+        stroke-linejoin="round" 
+        fill="none"/>
+</svg>

--- a/public/icons/icon-192x192.svg
+++ b/public/icons/icon-192x192.svg
@@ -1,0 +1,17 @@
+<svg width="192" height="192" viewBox="0 0 192 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background with rounded corners -->
+  <rect width="192" height="192" rx="42" fill="#1E4A73"/>
+  
+  <!-- Chart bars -->
+  <rect x="66" y="112" width="16" height="32" rx="2" fill="white"/>
+  <rect x="92" y="80" width="16" height="64" rx="2" fill="white"/>
+  <rect x="118" y="96" width="16" height="48" rx="2" fill="white"/>
+  
+  <!-- Upward arrow -->
+  <path d="M100 48 L100 116 M100 48 L85 63 M100 48 L115 63" 
+        stroke="white" 
+        stroke-width="8" 
+        stroke-linecap="round" 
+        stroke-linejoin="round" 
+        fill="none"/>
+</svg>

--- a/public/icons/icon-512x512.svg
+++ b/public/icons/icon-512x512.svg
@@ -1,0 +1,17 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background with rounded corners -->
+  <rect width="512" height="512" rx="112" fill="#1E4A73"/>
+  
+  <!-- Chart bars -->
+  <rect x="176" y="298" width="44" height="86" rx="5" fill="white"/>
+  <rect x="246" y="214" width="44" height="170" rx="5" fill="white"/>
+  <rect x="316" y="256" width="44" height="128" rx="5" fill="white"/>
+  
+  <!-- Upward arrow -->
+  <path d="M267 128 L267 310 M267 128 L227 168 M267 128 L307 168" 
+        stroke="white" 
+        stroke-width="22" 
+        stroke-linecap="round" 
+        stroke-linejoin="round" 
+        fill="none"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,24 +2,36 @@
   "name": "Stonks Portfolio Tracker",
   "short_name": "Stonks",
   "description": "Track your portfolio holdings, prices, and rebalancing recommendations",
-  "start_url": "/stonks",
+  "start_url": "/stonks/prices",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#0d6efd",
+  "theme_color": "#1E4A73",
   "orientation": "portrait-primary",
   "scope": "/stonks",
   "icons": [
     {
-      "src": "/stonks/icons/icon-192x192.png",
+      "src": "/stonks/icons/icon-192x192.svg",
       "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable any"
+      "type": "image/svg+xml",
+      "purpose": "any"
     },
     {
-      "src": "/stonks/icons/icon-512x512.png",
+      "src": "/stonks/icons/icon-512x512.svg",
       "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable any"
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/stonks/icons/icon-192x192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/stonks/icons/icon-512x512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
     }
   ],
   "categories": ["finance", "productivity", "business"],

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,6 +5,9 @@ const urlsToCache = [
   '/stonks/',
   '/stonks/prices',
   '/stonks/config',
+  '/stonks/ticker',
+  '/stonks/charts',
+  '/stonks/charts/large',
   '/stonks/manifest.json',
   'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css',
   'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js'

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,7 @@ export function generateHTMLHeader() {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Track your portfolio holdings, prices, and rebalancing recommendations">
-    <meta name="theme-color" content="#0d6efd">
+    <meta name="theme-color" content="#1E4A73">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Stonks">
@@ -19,9 +19,10 @@ export function generateHTMLHeader() {
     <link rel="manifest" href="/stonks/manifest.json">
     
     <!-- Icons -->
-    <link rel="icon" type="image/png" sizes="192x192" href="/stonks/icons/icon-192x192.png">
-    <link rel="icon" type="image/png" sizes="512x512" href="/stonks/icons/icon-512x512.png">
-    <link rel="apple-touch-icon" href="/stonks/icons/icon-192x192.png">
+    <link rel="icon" type="image/svg+xml" href="/stonks/icons/favicon.svg">
+    <link rel="icon" type="image/svg+xml" sizes="192x192" href="/stonks/icons/icon-192x192.svg">
+    <link rel="icon" type="image/svg+xml" sizes="512x512" href="/stonks/icons/icon-512x512.svg">
+    <link rel="apple-touch-icon" href="/stonks/icons/icon-192x192.svg">
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous">
@@ -30,7 +31,7 @@ export function generateHTMLHeader() {
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/stonks/sw.js', { scope: '/stonks/' })
+          navigator.serviceWorker.register('/stonks/sw.js')
             .then(registration => {
               console.log('Service Worker registered:', registration.scope);
             })


### PR DESCRIPTION
Replaced PNG icons with SVG versions for improved scalability and updated references in manifest.json, service worker, and HTML header. Changed theme color to #1E4A73 across the app. Added new favicon.svg and updated documentation in public/icons/README.md. Expanded service worker cache to include new routes.