### PR TITLE
Add no-cache headers to API responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,13 +198,23 @@ async function handleRequest(request, env) {
             portfolioName,
             totalTargetWeight
           }), {
-            headers: { 'content-type': 'application/json' }
+            headers: { 
+              'content-type': 'application/json',
+              'cache-control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+              'pragma': 'no-cache',
+              'expires': '0'
+            }
           });
         } catch (error) {
           console.error('Error in /api/config-data:', error);
           return new Response(JSON.stringify({ error: error.message }), {
             status: 500,
-            headers: { 'content-type': 'application/json' }
+            headers: { 
+              'content-type': 'application/json',
+              'cache-control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+              'pragma': 'no-cache',
+              'expires': '0'
+            }
           });
         }
       
@@ -213,7 +223,12 @@ async function handleRequest(request, env) {
           if (!finnhubService) {
             return new Response(JSON.stringify({ error: 'Finnhub API key not configured' }), {
               status: 503,
-              headers: { 'content-type': 'application/json' }
+              headers: { 
+                'content-type': 'application/json',
+                'cache-control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+                'pragma': 'no-cache',
+                'expires': '0'
+              }
             });
           }
           
@@ -323,13 +338,23 @@ async function handleRequest(request, env) {
             rebalanceMode,
             currency
           }), {
-            headers: { 'content-type': 'application/json' }
+            headers: { 
+              'content-type': 'application/json',
+              'cache-control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+              'pragma': 'no-cache',
+              'expires': '0'
+            }
           });
         } catch (error) {
           console.error('Error in /api/prices-data:', error);
           return new Response(JSON.stringify({ error: error.message }), {
             status: 500,
-            headers: { 'content-type': 'application/json' }
+            headers: { 
+              'content-type': 'application/json',
+              'cache-control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+              'pragma': 'no-cache',
+              'expires': '0'
+            }
           });
         }
       

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -650,6 +650,22 @@ describe('Index Router', () => {
           expect(holding.updated_at).toBeUndefined();
         }
       });
+
+      test('should include no-cache headers in config-data response', async () => {
+        mockRequest = createMockRequest('http://localhost/stonks/api/config-data');
+        
+        mockEnv.STONKS_DB.prepare.mockReturnValue({
+          all: vi.fn().mockResolvedValue({ results: [] }),
+          first: vi.fn().mockResolvedValue(null),
+          bind: vi.fn().mockReturnThis()
+        });
+        
+        const response = await workerHandler.fetch(mockRequest, mockEnv);
+        
+        expect(response.headers.get('cache-control')).toBe('no-store, no-cache, must-revalidate, proxy-revalidate');
+        expect(response.headers.get('pragma')).toBe('no-cache');
+        expect(response.headers.get('expires')).toBe('0');
+      });
     });
 
     describe('/stonks/api/prices-data', () => {
@@ -738,6 +754,33 @@ describe('Index Router', () => {
         
         expect(data.currency).toBe('SGD');
         expect(data.fxAvailable).toBe(true);
+      });
+
+      test('should include no-cache headers in prices-data response', async () => {
+        mockEnv.FINNHUB_API_KEY = 'test-key';
+        mockRequest = createMockRequest('http://localhost/stonks/api/prices-data');
+        
+        mockEnv.STONKS_DB.prepare.mockReturnValue({
+          all: vi.fn().mockResolvedValue({ results: [] }),
+          bind: vi.fn().mockReturnThis()
+        });
+        
+        const response = await workerHandler.fetch(mockRequest, mockEnv);
+        
+        expect(response.headers.get('cache-control')).toBe('no-store, no-cache, must-revalidate, proxy-revalidate');
+        expect(response.headers.get('pragma')).toBe('no-cache');
+        expect(response.headers.get('expires')).toBe('0');
+      });
+
+      test('should include no-cache headers in error responses', async () => {
+        mockRequest = createMockRequest('http://localhost/stonks/api/prices-data');
+        
+        const response = await workerHandler.fetch(mockRequest, mockEnv);
+        
+        expect(response.status).toBe(503);
+        expect(response.headers.get('cache-control')).toBe('no-store, no-cache, must-revalidate, proxy-revalidate');
+        expect(response.headers.get('pragma')).toBe('no-cache');
+        expect(response.headers.get('expires')).toBe('0');
       });
     });
 


### PR DESCRIPTION
Added 'cache-control', 'pragma', and 'expires' headers to all /api/config-data and /api/prices-data responses, including error cases, to prevent caching. Updated tests to verify the presence of these headers in both success and error responses.